### PR TITLE
Bugfix: Allow openvpn-client to be ran without running openvpn

### DIFF
--- a/tasks/create_client.yml
+++ b/tasks/create_client.yml
@@ -17,7 +17,7 @@
 
 - name: Slurp recommended client config
   slurp:
-    src: "{{ hostvars[openvpn_client_server_name].openvpn_base_dir }}/{{ openvpn_client_config_identifier }}.ovpn"
+    src: "/etc/openvpn/{{ openvpn_client_config_identifier }}.ovpn"
   register: openvpn_client_remote_config_file
   delegate_to: "{{ openvpn_client_server_name }}"
   when: openvpn_client.local_config_path is not defined


### PR DESCRIPTION
The openvpn-client role can now be run without running the openvpn (server)
role as well. Previously that wasn't possible (if pulling the client config
file from a server) because the host variable openvpn_base_dir then wasn't
be set for the server.